### PR TITLE
Update xssinspector.py

### DIFF
--- a/xssinspector.py
+++ b/xssinspector.py
@@ -1666,8 +1666,8 @@ def get_arguments():
     # Create the argument parser with RawTextHelpFormatter to preserve formatting
     parser = argparse.ArgumentParser(
         description=f"""
-{BLUE}{r"""XSS Inspector v.0.1 | Advanced URL Processor: v.0.0.1 | Add-ons: v.0.0.1 | Obfuscation: 96 Filters | Core Version: v.0.1"""}{END}
-{MAGENTA}{r"""Programmed by: Haroon Ahmad Awan (haroon@cyberzeus.pk)"""}{END}
+{BLUE}{f"XSS Inspector v.0.1 | Advanced URL Processor: v.0.0.1 | Add-ons: v.0.0.1 | Obfuscation: 96 Filters | Core Version: v.0.1"}{END}
+{MAGENTA}{f"Programmed by: Haroon Ahmad Awan (haroon@cyberzeus.pk)"}{END}
         """,
         formatter_class=argparse.RawTextHelpFormatter  # This ensures your formatting is preserved
     )


### PR DESCRIPTION
The current implementation of the `argparse.ArgumentParser` description uses constructs like:

```python
{BLUE}{r""" ... """}{END}
```

inside an f-string. This is not valid Python syntax because f-strings expect an expression inside `{}`, not a raw string literal. This causes a `SyntaxError: f-string: expecting '}'` at runtime.

I’ve adjusted the code so the banner is built using proper f-strings with variable interpolation.